### PR TITLE
Null-safety for auto listener

### DIFF
--- a/src/main/java/org/tahomarobotics/robot/auto/Autonomous.java
+++ b/src/main/java/org/tahomarobotics/robot/auto/Autonomous.java
@@ -78,7 +78,13 @@ public class Autonomous extends SubsystemIF {
         inst.addListener(
                 inst.getBooleanTopic("/FMSInfo/IsRedAlliance").getEntry(true),
                 EnumSet.of(NetworkTableEvent.Kind.kValueAll),
-                e -> this.onAutoChange(autoChooser.get().getName())
+                e -> {
+                    var command = autoChooser.get();
+                    if (command != null)
+                        this.onAutoChange(command.getName());
+                    else
+                        this.onAutoChange(AutoConstants.DEFAULT_AUTO_NAME);
+                }
         );
     }
 


### PR DESCRIPTION
It crashed because `/FMSInfo/IsRedAlliance` changed prior to the `LoggedDashboardChooser` being published/updated.